### PR TITLE
Publish playlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 Dynamic Playlists (Under Development)
 
+Major TODOS before release:
+- Publish a playlist to spotify (🔨🚧🏗️)
+- Update playlist with new tracks during listening through DP app
+- Scrolling for longer playlists
+- Support drag n drop for slot positioning
+- Delete slots
+- Spotify attributions & branding guidelines
+- Global snackbar to handle API error messages
+- Testing
+- Refactor pools
+
 A Spotify web player where you can design dynamic playlists that autorefresh with new songs as you listen.
 In a dynamic playlist you can add tracks, which behave normally, or slots, which will rotate between songs from a selection of songs as you listen. Slots can be populated with artists, albums, or playlists. (Support for recommendations is planned but will not be in the initial release.)
 

--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -55,12 +55,33 @@ const StyledDialogContent = styled(DialogContent)({
   backgroundColor: '#282c34',
 });
 
+const sortPlaylistsByLastUpdated = (playlists: PlaylistType[]) => {
+  // sort playlists by last updated, newest first. If no last updated, sort by created at
+  return playlists.sort((a, b) => {
+    const aLastUpdated = new Date(a.last_updated);
+    const bLastUpdated = new Date(b.last_updated);
+    const aCreatedAt = new Date(a.created_at);
+    const bCreatedAt = new Date(b.created_at);
+    if (bLastUpdated === null && aLastUpdated === null) {
+      return bCreatedAt.getTime() - aCreatedAt.getTime();
+    } else if (bLastUpdated === null) {
+      return -1;
+    } else if (aLastUpdated === null) {
+      return 1;
+    } else if (bLastUpdated.getTime() === aLastUpdated.getTime()) {
+      return bCreatedAt.getTime() - aCreatedAt.getTime();
+    }
+    return bLastUpdated.getTime() - aLastUpdated.getTime();
+  });
+}
+
 function Home() {
   const { userid } = useParams();
   const { currToken, setTokenContext } = useTokenContext();
   const [openCreatePlaylist, setOpenCreatePlaylist] = useState(false);
   const [newPlaylistTitle, setNewPlaylistTitle] = useState('');
   const [selectedPlaylist, setSelectedPlaylist] = useState<PlaylistType>();
+  // TODO: move error handling to context for global snackbar?
   const [apiError, setApiError] = useState('');
   const [playlists, setPlaylists] = useState<PlaylistType[]>([]);
   const { setUserIdContext } = useUserContext();
@@ -131,7 +152,8 @@ function Home() {
       if (errorMsg) {
         console.error(errorMsg);
       } else {
-        setPlaylists(data);
+        const sorted = sortPlaylistsByLastUpdated(data);
+        setPlaylists(sorted);
       }
     }
 

--- a/client/src/components/Playlist.tsx
+++ b/client/src/components/Playlist.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import ListItem from './presentational/ListItem';
 import { Typography, Button } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import AddIcon from '@mui/icons-material/Add';
@@ -8,12 +7,18 @@ import PersonIcon from '@mui/icons-material/Person';
 import AlbumIcon from '@mui/icons-material/Album';
 import AudiotrackIcon from '@mui/icons-material/Audiotrack';
 import QueueMusicIcon from '@mui/icons-material/QueueMusic';
+import PublishIcon from '@mui/icons-material/Publish';
+
+import ListItem from './presentational/ListItem';
 import { SLOT_TYPES_MAP_BY_ID, SLOT_TYPES_MAP_BY_NAME } from '../constants';
 import callApi from '../utils/callApi';
-import { BaseSlot, FullSlot, PlaylistType, SearchResultOption, SpotifyEntry } from '../types/index.js';
+import { BaseSlot, FullSlot, PlaylistType, PoolTrack, SearchResultOption, SpotifyAlbumType, SpotifyEntry } from '../types/index.js';
 import BaseDialog from './forms/BaseDialog';
 import EditSlot from './forms/EditSlot';
 import { requiresArtist } from '../utils';
+import useSpotifyApi from '../utils/useSpotifyApi';
+import { useTokenContext } from '../contexts/token';
+import { useUserContext } from '../contexts/user';
 
 const iconTypeMapping = {
   [SLOT_TYPES_MAP_BY_NAME.track]: <AudiotrackIcon />,
@@ -34,8 +39,14 @@ const ListTitle = styled(Typography)({
   color: 'white',
 });
 
-const CreateSlotButton = styled(Button)({
+const PlaylistActionButton = styled(Button)({
   marginBottom: '15px',
+});
+
+const PlaylistActionsContainer = styled('div')({
+  display: 'flex',
+  width: '140px',
+  justifyContent: 'space-between',
 });
 
 const SlotInnerContent = styled('div')({
@@ -51,6 +62,11 @@ type Props = {
   setApiError: (error: string) => void;
 }
 
+const pickRandomTrack = (pool: PoolTrack[]) => {
+  const randomIndex = Math.floor(Math.random() * pool.length);
+  return pool[randomIndex];
+}
+
 function Playlist({
   playlist,
   setApiError
@@ -62,6 +78,9 @@ function Playlist({
   const [selectedOption, setSelectedOption] = useState<SearchResultOption | null>(null);
   const [slotType, setSlotType] = useState(selectedSlot?.type ? SLOT_TYPES_MAP_BY_ID[selectedSlot.type] : '');
   const editMode = !!selectedSlot;
+  const { currToken } = useTokenContext();
+  const { userId } = useUserContext();
+  const { callSpotifyApi } = useSpotifyApi();
 
   const openCreateSlotForm = () => {
     setOpenEditSlotDialog(true);
@@ -76,6 +95,196 @@ function Playlist({
     setSelectedEntry(null);
     setSelectedOption(null);
   }
+
+  const getAlbumTracks = async (spotifyId: string): Promise<Array<PoolTrack> | undefined> => {
+    // TODO: rework pools
+    // if (poolNeedsUpdating) {
+    const input = {
+      method: 'GET',
+      path: `albums/${spotifyId}/tracks`,
+      token: currToken,
+    }
+    const { errorMsg, data } = await callSpotifyApi(input);
+    if (!errorMsg && data) {
+      const tracks = data.items.map(({ id, name, artists }: SpotifyAlbumType) => ({
+        // pool_id: poolId,
+        name,
+        spotify_track_id: id,
+        spotify_artist_ids: artists.map((artist: any) => artist.id)
+      }));
+      // save tracks to pool
+      // console.log('saving tracks to pool');
+      // await callApi({
+      //   method: 'POST',
+      //   path: `pool-tracks/by-pool/${poolId}`,
+      //   data: tracks,
+      // });
+      return tracks;
+    } else {
+      console.log('Could not retrieve tracks from spotify', errorMsg)
+      console.log('callSpotifyApi input', input)
+    }
+    // }
+    // const input = {
+    //   method: 'GET',
+    //   path: `pool-tracks/by-pool/${poolId}`,
+    //   token: currToken,
+    // }
+    // const { errorMsg, data } = await callApi(input);
+    // if (!errorMsg && data) {
+    //   return data;
+    // } else {
+    //   console.log('Could not retrieve tracks from db', errorMsg)
+    //   console.log('callApi input', input)A
+    // }
+  }
+
+  const publishPlaylist = async () => {
+    let spotifyPlaylistId = playlist.spotify_id;
+    // if playlist has never been published before, create new playlist in spotify
+    // TODO: support descriptions
+    // TODO: support private playlists
+    if (!spotifyPlaylistId) {
+      // spotify api call to create a new empty playlist
+      const { errorMsg, data } = await callSpotifyApi({
+        method: 'POST',
+        path: `users/${userId}/playlists`,
+        token: currToken,
+        data: {
+          name: playlist.title,
+        }
+      });
+      if (errorMsg) {
+        console.log('Error creating playlist in Spotify', errorMsg);
+        return;
+      }
+      const { id: newSpotifyPlaylistId } = data;
+
+      // save spotify playlist id to playlist in dp db
+      const { errorMsg: errorMsg2 } = await callApi({
+        method: 'PUT',
+        path: `playlists/${playlist.id}`,
+        data: {
+          spotify_id: newSpotifyPlaylistId,
+          last_updated_by: userId,
+        }
+      });
+      if (errorMsg2) {
+        console.log('Error saving spotify playlist id to playlist in db', errorMsg2);
+        return;
+      } else {
+        spotifyPlaylistId = newSpotifyPlaylistId;
+      }
+    } else {
+      // clear existing playlist in spotify
+      const { errorMsg } = await callSpotifyApi({
+        method: 'PUT',
+        path: `playlists/${spotifyPlaylistId}/tracks`,
+        token: currToken,
+        data: {
+          uris: [],
+        }
+      });
+      if (errorMsg) {
+        console.log('Error clearing playlist in Spotify', errorMsg);
+        return;
+      };
+    }
+
+    // update spotify playlist with current slots
+    // convert each slot to a spotify uri of a track
+    const uris = await Promise.all(slots.map(async (slot) => {
+      const { type, name, pool_id, pool_spotify_id } = slot;
+      // TODO: figure out if this is timing I want for updating
+      // const poolNeedsUpdating = !pool_last_updated || new Date(pool_last_updated) < new Date(playlist.last_updated);
+      switch (type) {
+        case SLOT_TYPES_MAP_BY_NAME.track:
+          return `spotify:track:${pool_spotify_id}`;
+        case SLOT_TYPES_MAP_BY_NAME.album:
+          if (!pool_id || !pool_spotify_id) {
+            console.log('Expected pool_id & pool_spotify_id for album slot')
+            return;
+          }
+          // get album tracks
+          const albumTracks = await getAlbumTracks(pool_spotify_id);
+          if (albumTracks) {
+            // pick a track
+            const track = pickRandomTrack(albumTracks);
+            if (track) {
+              return `spotify:track:${track.spotify_track_id}`;
+            }
+          }
+          console.log('No uri added for album slot: ', slot.id, ' name: ', name, ' spotify id: ', pool_spotify_id);
+          break;
+        case SLOT_TYPES_MAP_BY_NAME.artist:
+          if (!pool_id || !pool_spotify_id) {
+            console.log('Expected pool_id & pool_spotify_id for artist slot')
+            return;
+          }
+          // get artist albums
+          const { errorMsg, data } = await callSpotifyApi({
+            method: 'GET',
+            path: `artists/${pool_spotify_id}/albums`,
+            token: currToken,
+          });
+          if (errorMsg) {
+            console.log('Error clearing playlist in Spotify', errorMsg);
+            return;
+          }
+          const { items } = data;
+          // get tracks from each album
+          const allTracks = (await Promise.all(items.map(async (album: any) => getAlbumTracks(album.id)))).flat();
+          if (allTracks.length) {
+            // pick a track
+            const track = pickRandomTrack(allTracks);
+            if (track) {
+              return `spotify:track:${track.spotify_track_id}`;
+            }
+          }
+          console.log('No uri added for artist slot: ', slot.id, ' name: ', ' spotify id: ', pool_spotify_id);
+          break;
+        default: console.log('Unexpected slot type', type);
+        // copilot just threw this in. Will check it later when I implement playlist support
+        // case SLOT_TYPES_MAP_BY_NAME.playlist:
+        //   // get playlist tracks
+        //   const { errorMsg: errorMsg2, data: data2 } = await callSpotifyApi({
+        //     method: 'GET',
+        //     path: `playlists/${pool_spotify_id}/tracks`,
+        //     token: currToken,
+        //   });
+        //   if (errorMsg2) {
+        //     console.log('Error clearing playlist in Spotify', errorMsg2);
+        //     return;
+        //   }
+        //   const { items: playlistTracks } = data2;
+        //   // save playlist tracks to pool
+        //   await callApi({
+        //     method: 'POST',
+        //     path: 'pool-tracks/',
+        //     data: playlistTracks.map(({ track }: any) => ({
+        //       pool_id,
+      }
+    }));
+    // remove undefined uris
+    const filteredUris = uris.filter((uri, index) => {
+      if (!uri) {
+        console.log('undefined uri at index ', index);
+      }
+      return !!uri;
+    });
+    // update spotify playlist with selected tracks
+    const { errorMsg } = await callSpotifyApi({
+      method: 'PUT',
+      path: `playlists/${spotifyPlaylistId}/tracks`,
+      token: currToken,
+      data: {
+        uris: filteredUris,
+      }
+    });
+    if (errorMsg) {
+      console.log('Error updating playlist in Spotify', errorMsg);
+    }
+  }  
 
   const selectSlotToEdit = (id: string) => {
     const slot = slots.find((slot) => slot.id === id);
@@ -165,9 +374,14 @@ function Playlist({
     <>
       <ListHeader>
         <ListTitle>{playlist.title}</ListTitle>
-        <CreateSlotButton variant="contained" onClick={openCreateSlotForm}>
-          <AddIcon />
-        </CreateSlotButton>
+        <PlaylistActionsContainer>
+          <PlaylistActionButton variant="contained" onClick={openCreateSlotForm}>
+            <AddIcon />
+          </PlaylistActionButton>
+          <PlaylistActionButton variant="contained" onClick={publishPlaylist}>
+            <PublishIcon />
+          </PlaylistActionButton>
+        </PlaylistActionsContainer>
       </ListHeader>
       {slots.map(slot => {
         const label = slot.name + (requiresArtist(slot.type) && slot.artist_name?.length ? ' - ' + slot.artist_name.join(', ') : '')

--- a/client/src/components/WebPlayback.tsx
+++ b/client/src/components/WebPlayback.tsx
@@ -103,7 +103,6 @@ function WebPlayback() {
           getOAuthToken: cb => { cb(currToken); },
           volume: 0.5
         });
-
         setPlayer(player);
 
         player.addListener('ready', async ({ device_id }) => {
@@ -173,7 +172,7 @@ function WebPlayback() {
         <PlayerCard id="web-playback">
           {currentTrack && 
             <TrackInfoContainer>
-              {/* @ts-expect-error */}
+              {/* @ts-expect-error component might not be showing because of style wrapper, but it's needed */}
               <TrackImage component="img" image={currentTrack.album.images[0].url} alt="Album cover thumbnail" />
               <TrackInfo>
                 <div className="scroll-container" style={{ flexGrow: '1' }}>

--- a/client/src/components/forms/EditSlot.tsx
+++ b/client/src/components/forms/EditSlot.tsx
@@ -45,7 +45,7 @@ function EditSlot({
 
   return (
     <>
-      <StyledDialogTitle>{createMode ? 'Edit Slot' : 'Create a new slot'}</StyledDialogTitle>
+      <StyledDialogTitle>{createMode ? 'Create a new slot' : 'Edit Slot'}</StyledDialogTitle>
       <StyledDialogContent>
         <InputLabel>Slot Type</InputLabel>
         <Select

--- a/client/src/components/forms/inputs/SpotifySearch.tsx
+++ b/client/src/components/forms/inputs/SpotifySearch.tsx
@@ -45,6 +45,7 @@ function SearchInput({ selectedOption, setSelectedOption, setSelectedEntry, slot
                 type: slotType
               },
               token: currToken,
+              dataAsQueryParams: true,
             });
             if (errorMsg) {
               console.error(errorMsg);

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -6,7 +6,7 @@ export const SLOT_TYPES_MAP_BY_ID = {
   1: 'track',
   2: 'artist',
   3: 'album',
-  4: 'playlist',
+  // 4: 'playlist',
 }
 
 export const SLOT_TYPES_MAP_BY_NAME: Record<string, keyof typeof SLOT_TYPES_MAP_BY_ID> = Object.entries(SLOT_TYPES_MAP_BY_ID)
@@ -19,7 +19,7 @@ export const SLOT_TYPE_TO_SPOTIFY_RETURN_TYPE = {
   [SLOT_TYPES_MAP_BY_ID[1]]: 'tracks',
   [SLOT_TYPES_MAP_BY_ID[2]]: 'artists',
   [SLOT_TYPES_MAP_BY_ID[3]]: 'albums',
-  [SLOT_TYPES_MAP_BY_ID[4]]: 'playlists',
+  // [SLOT_TYPES_MAP_BY_ID[4]]: 'playlists',
 }
 
 export type SlotType = typeof SLOT_TYPES_MAP_BY_ID[keyof typeof SLOT_TYPES_MAP_BY_ID];

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -7,20 +7,20 @@ export type User = {
 export interface PlaylistType {
   id: string;
   spotify_id?: string;
-  created_at: Date;
+  created_at: string;
   created_by: string;
-  last_updated: Date;
+  last_updated: string;
   last_updated_by: string;
   title: string;
 }
 
 export interface FullSlot extends BaseSlot {
   id: string;
-  created_at: Date;
-  last_updated?: Date;
+  created_at: string;
+  last_updated?: string;
   pool_id?: string;
   pool_spotify_id: string;
-  pool_last_updated: Date;
+  pool_last_updated: string;
   playlist_id: string;
 }
 
@@ -65,4 +65,11 @@ export type SearchResultOption = {
   imageUrl?: string;
   value: string;
   altText?: string;
+}
+
+export type PoolTrack = {
+  id: string;
+  pool_id: string;
+  spotify_track_id: string;
+  spotify_artist_ids?: Array<string>;
 }

--- a/client/src/utils/refreshToken.ts
+++ b/client/src/utils/refreshToken.ts
@@ -8,15 +8,18 @@ const useRefreshToken = () => {
   const { userId } = useUserContext();
 
   const refreshToken = async (): Promise<string | undefined> => { 
-    const res = await callApi({
+    const { errorMsg, access_token } = await callApi({
       baseUrl: SERVER_BASE_URL,
       path: `auth/token/${userId}/refresh`,
       method: 'POST',
     });
-    console.log('refresh token res', res);
-    if (res.access_token) {
-      setTokenContext(res.access_token);
-      return res.access_token;
+    if (errorMsg) {
+      console.log(errorMsg);
+      return;
+    }
+    if (access_token) {
+      setTokenContext(access_token);
+      return access_token;
     }
   };
   return { refreshToken };

--- a/client/src/utils/useSpotifyApi.ts
+++ b/client/src/utils/useSpotifyApi.ts
@@ -1,4 +1,5 @@
 import { SPOTIFY_BASE_URL } from "../constants";
+import { useTokenContext } from "../contexts/token";
 import callApi from "./callApi";
 import useRefreshToken from "./refreshToken";
 
@@ -8,15 +9,22 @@ type Props = {
   path: string;
   data?: any;
   token?: string;
+  dataAsQueryParams?: boolean;
 }
 const useSpotifyApi = () => {
   const { refreshToken } = useRefreshToken();
+  const { currToken } = useTokenContext();
   const callSpotifyApi = async (props: Props): Promise<any> => {
-    const params = new URLSearchParams(props.data);
+    let path = props.path;
+    if (props.dataAsQueryParams) {
+      const params = new URLSearchParams(props.data);
+      path = `${path}?${params.toString()}`;
+    }
     let res = await callApi({
       baseUrl: SPOTIFY_BASE_URL,
+      token: currToken,
       ...props,
-      path: `${props.path}?${params.toString()}`,
+      path,
     })
     if (res.errorMsg && res.errorMsg.includes('expired')) {
       // TODO: implement PKCE auth flow
@@ -45,7 +53,7 @@ const useSpotifyApi = () => {
           baseUrl: SPOTIFY_BASE_URL,
           ...props,
           token: newToken,
-          path: `${props.path}?${params.toString()}`,
+          path,
         })
     }
     return res;

--- a/server/migrations/1695441286710_update-pool-track-spotify-artist-ids-array.sql
+++ b/server/migrations/1695441286710_update-pool-track-spotify-artist-ids-array.sql
@@ -1,0 +1,13 @@
+-- Up Migration
+ALTER TABLE pool_track
+RENAME COLUMN spotify_artist_id TO spotify_artist_ids;
+
+ALTER TABLE pool_track
+ALTER COLUMN spotify_artist_ids TYPE varchar[] USING ARRAY[spotify_artist_ids];
+
+-- Down Migration
+ALTER TABLE pool_track
+ALTER COLUMN spotify_artist_ids TYPE varchar USING array_to_string(spotify_artist_ids, ',');
+
+ALTER TABLE pool_track
+RENAME COLUMN spotify_artist_ids TO spotify_artist_id;

--- a/server/routes/api/index.ts
+++ b/server/routes/api/index.ts
@@ -10,7 +10,7 @@ const apiRouter = Router();
 apiRouter.use("/users", usersRouter);
 apiRouter.use("/playlists", playlistsRouter);
 apiRouter.use("/pools", poolsRouter);
-apiRouter.use("/poolTracks", poolTracksRouter);
+apiRouter.use("/pool-tracks", poolTracksRouter);
 apiRouter.use("/slots", slotsRouter);
 
 

--- a/server/routes/api/poolTracks/index.ts
+++ b/server/routes/api/poolTracks/index.ts
@@ -70,11 +70,12 @@ poolTracksRouter.get('/by-spotify-artist-id/:spotifyArtistId', async (req: Reque
 });
 
 // Insert pool tracks
-poolTracksRouter.post('/', async (req: Request, res: Response) => {
+poolTracksRouter.post('/by-pool/:poolId', async (req: Request, res: Response) => {
   const poolTracks: Omit<PoolTrack, 'id'>[] = req.body;
+  const { poolId } = req.params;
 
   try {
-    await insertPoolTracks(poolTracks);
+    await insertPoolTracks(poolTracks, poolId);
     return res.status(201).send('Pool tracks inserted');
   } catch (err: any) {
     const errMsg = err?.message || err;

--- a/server/services/pool/index.ts
+++ b/server/services/pool/index.ts
@@ -30,8 +30,8 @@ const createPool = async (pool: Omit<Pool, 'id' | 'last_updated'>): Promise<Pool
     return poolRows[0];
   }
   const { rows } = await connectionPool.query(
-    `INSERT INTO pool (spotify_id, last_updated)
-    VALUES ($1, NOW())
+    `INSERT INTO pool (spotify_id)
+    VALUES ($1)
     ON CONFLICT (spotify_id)
     DO NOTHING
     RETURNING *`,

--- a/server/services/pool_track/index.ts
+++ b/server/services/pool_track/index.ts
@@ -1,5 +1,6 @@
 import { pool as connectionPool } from '../../index.js';
 import { PoolTrack } from '../../types/index.js';
+import { setPoolLastUpdated } from '../pool/index.js';
 
 const getPoolTrackById = async (id: string): Promise<PoolTrack | null> => {
   const { rows } = await connectionPool.query(
@@ -41,17 +42,22 @@ const getPoolTracksBySpotifyArtistId = async (spotifyArtistId: string): Promise<
   return rows.length > 0 ? rows[0] : null;
 };
 
-const insertPoolTracks = async (poolTracks: Omit<PoolTrack, 'id'>[]): Promise<void> => {
+const insertPoolTracks = async (poolTracks: Omit<PoolTrack, 'id'>[], poolId: string): Promise<void> => {
+  const res = await setPoolLastUpdated(poolId);
+  if (!res) {
+    throw new Error(`Failed to update pool last_updated for pool_id: ${poolId}`);
+  }
   const values = poolTracks.map((poolTrack) => {
-    const { pool_id, spotify_track_id, spotify_artist_id } = poolTrack;
-    if (!pool_id || !spotify_track_id || !spotify_artist_id) {
-      console.log(`Skipping track with missing required field(s): `, { pool_id, spotify_track_id, spotify_artist_id });
+    const { pool_id, spotify_track_id, spotify_artist_ids } = poolTrack;
+    if (!pool_id || !spotify_track_id || !spotify_artist_ids) {
+      console.log(`Skipping track with missing required field(s): `, { pool_id, spotify_track_id, spotify_artist_ids });
     } else {
-      return `('${pool_id}', '${spotify_track_id}, ${spotify_artist_id}')`
+      const formattedArtistIds = `'{${spotify_artist_ids.join(',')}}'`;
+      return `('${pool_id}', '${spotify_track_id}', ${formattedArtistIds})`;
     }
   }).join(',');
   await connectionPool.query(
-    `INSERT INTO pool_tracks (pool_id, track_id)
+    `INSERT INTO pool_track (pool_id, spotify_track_id, spotify_artist_ids)
      VALUES ${values}`
   );
 };

--- a/server/types/index.ts
+++ b/server/types/index.ts
@@ -35,6 +35,6 @@ export interface PoolTrack {
   id: UUID;
   pool_id: UUID;
   spotify_track_id: string;
-  spotify_artist_id: string;
+  spotify_artist_ids?: Array<string>; // For future feature of banning artists
 }
 


### PR DESCRIPTION
This PR adds the ability to publish a playlist to spotify.
- Also sorts playlists by lastUpdated then createdAt (newest first)
- Putting pool handling on hold until I figured out how to re-work it.
   - Realized pools would benefit from being album scoped because if one person wants a pool of x artist and a second person wants a pool of just one of that artist's albums, it doesn't necessarliy make sense to repeat that data, but I'm not prepared to think through how complicated it might get to re-work the data model so we can pull multiple pools for artist slots. And also need to think through if this will impact future types like playlists or recommendations
 -  callSpotifyApi handles data in the body as well as query params now
 - migration to convert `spotify_artist_id` to `spotify_artist_ids` and store as an array in table `pool_track`