### PR TITLE
Dynamic updates to playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Major TODOS before release:
 - Global snackbar to handle API error messages
 - Testing
 - Refactor pools
+- Button to start playing a playlist
 
 Misc Todos:
 - add switch to web playback button
 - shuffle
-- 
 
 A Spotify web player where you can design dynamic playlists that autorefresh with new songs as you listen.
 In a dynamic playlist you can add tracks, which behave normally, or slots, which will rotate between songs from a selection of songs as you listen. Slots can be populated with artists, albums, or playlists. (Support for recommendations is planned but will not be in the initial release.)

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -14,10 +14,15 @@ function Login() {
     if (previouslyAuthorized) {
       // TODO: refactor to one function that can also be used in RequstToken
       // get spotify user id
-      const { data: { id: spotifyUserId } } = await callSpotifyApi({
+      const { errorMsg, data } = await callSpotifyApi({
         method: "GET",
         path: "me",
       });
+      if (errorMsg || !data) {
+        console.log('error logging in', errorMsg, data);
+        return;
+      }
+      const { id: spotifyUserId } = data;
       // double-check user exists in dp db as well
       if (spotifyUserId) {
         const { data: dpUser } = await callApi({

--- a/client/src/components/forms/EditSlot.tsx
+++ b/client/src/components/forms/EditSlot.tsx
@@ -2,7 +2,7 @@ import { BaseSlot, FullSlot, SearchResultOption, SpotifyEntry } from "../../type
 import styled from "@emotion/styled";
 import DialogTitle from "@mui/material/DialogTitle";
 import DialogContent from "@mui/material/DialogContent";
-import { SLOT_TYPES, SLOT_TYPES_MAP_BY_NAME } from "../../constants";
+import { SLOT_TYPES_LIST, SLOT_TYPES_MAP_BY_NAME } from "../../constants";
 import MenuItem from "@mui/material/MenuItem";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import InputLabel from "@mui/material/InputLabel";
@@ -61,7 +61,7 @@ function EditSlot({
           value={slotType}
           onChange={(event: SelectChangeEvent) => handleSelect(event.target.value)}
         >
-          {SLOT_TYPES.map((slotType) => {
+          {SLOT_TYPES_LIST.map((slotType) => {
             return (
               <MenuItem key={slotType} value={slotType}>{slotType}</MenuItem>
             )

--- a/client/src/constants/index.ts
+++ b/client/src/constants/index.ts
@@ -2,10 +2,17 @@ export const SPOTIFY_BASE_URL = 'https://api.spotify.com/v1/';
 
 export const SERVER_BASE_URL = 'http://localhost:5000/';
 
+export const SLOT_TYPES = {
+  track: 'track',
+  artist: 'artist',
+  album: 'album',
+  playlist: 'playlist',
+}
+
 export const SLOT_TYPES_MAP_BY_ID = {
-  1: 'track',
-  2: 'artist',
-  3: 'album',
+  1: SLOT_TYPES.track,
+  2: SLOT_TYPES.artist,
+  3: SLOT_TYPES.album,
   // 4: 'playlist',
 }
 
@@ -24,6 +31,6 @@ export const SLOT_TYPE_TO_SPOTIFY_RETURN_TYPE = {
 
 export type SlotType = typeof SLOT_TYPES_MAP_BY_ID[keyof typeof SLOT_TYPES_MAP_BY_ID];
 
-export const SLOT_TYPES:SlotType[] = Object.values(SLOT_TYPES_MAP_BY_ID) as SlotType[];
+export const SLOT_TYPES_LIST:SlotType[] = Object.values(SLOT_TYPES_MAP_BY_ID) as SlotType[];
 
 export const SLOT_TYPES_THAT_REQUIRE_ARTIST = [SLOT_TYPES_MAP_BY_NAME.track, SLOT_TYPES_MAP_BY_NAME.album, SLOT_TYPES_MAP_BY_NAME.playlist];

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -14,9 +14,14 @@ export interface PlaylistType {
   title: string;
 }
 
+export interface PlaylistWithSlots extends PlaylistType {
+  slots: Array<FullSlot>;
+}
+
 export interface FullSlot extends BaseSlot {
   id: string;
   created_at: string;
+  current_track?: string; // spotify id
   last_updated?: string;
   pool_id?: string;
   pool_spotify_id: string;

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -60,6 +60,7 @@ export type SpotifyTrackType = {
   album: SpotifyAlbumType;
   artists: Array<SpotifyArtistType>;
   name: string;
+  uri: string;
 }
 
 

--- a/client/src/utils/callApi.ts
+++ b/client/src/utils/callApi.ts
@@ -53,7 +53,7 @@ const callApi = async ({
     };
   } catch (error: any) {
     const errorMsg = getErrorMessage(error);
-    console.log('callApi input: ', { baseUrl, method, path, data, token });
+    console.log('callApi input: ', { baseUrl, method, path, data: JSON.stringify(data), token });
     console.error('callApi error: ', errorMsg, error);
     return {
       errorMsg,

--- a/client/src/utils/callApi.ts
+++ b/client/src/utils/callApi.ts
@@ -9,6 +9,7 @@ type Props = {
   data?: any;
   token?: string;
   headers?: Header;
+  signal?: AbortSignal;
 }
 
 type Header = {
@@ -30,18 +31,18 @@ const callApi = async ({
   data,
   token,
   headers,
+  signal,
 }: Props): Promise<any> => {
   try {
     const axiosInput: AxiosInput = {
         method,
         url: `${baseUrl || `${SERVER_BASE_URL}api/`}${path}`,
         data,
+        ...(signal ? { signal } : {}),
+        ...(headers ? { headers } : {})
     }
     if (tokenExists(token)) {
-      axiosInput.headers = { Authorization: `Bearer ${token}` }
-    }
-    if (headers) {
-      axiosInput.headers = { ...headers }
+      axiosInput.headers = { ...axiosInput.headers, Authorization: `Bearer ${token}` }
     }
     const res = await axios(axiosInput);
     if (res.data.error) {
@@ -55,7 +56,7 @@ const callApi = async ({
     console.log('callApi input: ', { baseUrl, method, path, data, token });
     console.error('callApi error: ', errorMsg, error);
     return {
-      errorMsg: getErrorMessage(errorMsg) || error,
+      errorMsg,
     };
   }
 };

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -11,13 +11,14 @@ export const getToken = () => {
   return localStorage.getItem('access_token');
 }
 
-export const setToken = (token: string) => {
-  if (!token || token === 'undefined') {
-    throw new Error(`Missing or invalid token: ${token}`)
+export const setTokens = (accessToken: string, refreshToken: string) => {
+  if (!tokenExists(accessToken) && !tokenExists(refreshToken)) {
+    throw new Error(`Missing or invalid token: ${accessToken}, ${refreshToken}`);
   }
-  localStorage.setItem('access_token', token);
+  localStorage.setItem('access_token', accessToken);
+  localStorage.setItem('refresh_token', refreshToken);
 }
 
 export const tokenExists = (token?: string | null) => !!token && token !== 'undefined';
 
-export const getErrorMessage = (error: any) => error?.response?.data?.error?.message || error?.message;
+export const getErrorMessage = (error: any) => error?.response?.data?.error?.message || error?.response?.data?.error || error?.message;

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -1,4 +1,6 @@
 import { SLOT_TYPES_MAP_BY_ID, SLOT_TYPES_MAP_BY_NAME, SLOT_TYPES_THAT_REQUIRE_ARTIST } from "../constants";
+import { FullSlot, PoolTrack, SpotifyAlbumType } from "../types";
+import callApi from "./callApi";
 
 export const requiresArtist = (type: keyof typeof SLOT_TYPES_MAP_BY_ID | keyof typeof SLOT_TYPES_MAP_BY_NAME) => {
   if (typeof type === 'string') {
@@ -22,3 +24,202 @@ export const setTokens = (accessToken: string, refreshToken: string) => {
 export const tokenExists = (token?: string | null) => !!token && token !== 'undefined';
 
 export const getErrorMessage = (error: any) => error?.response?.data?.error?.message || error?.response?.data?.error || error?.message;
+type PoolTrackWithName = PoolTrack & { name?: string };
+const pickRandomTrack = (pool: PoolTrackWithName[]) => {
+  const randomIndex = Math.floor(Math.random() * pool.length);
+  return pool[randomIndex];
+}
+
+const getAlbumTracks = async (spotifyId: string, callSpotifyApi: Function): Promise<Array<PoolTrack> | undefined> => {
+  // TODO: rework pools
+  // if (poolNeedsUpdating) {
+  const input = {
+    method: 'GET',
+    path: `albums/${spotifyId}/tracks`,
+  }
+  const { errorMsg, data } = await callSpotifyApi(input);
+  if (!errorMsg && data) {
+    const tracks = data.items.map(({ id, name, artists }: SpotifyAlbumType) => ({
+      // pool_id: poolId,
+      name,
+      spotify_track_id: id,
+      spotify_artist_ids: artists.map((artist: any) => artist.id)
+    }));
+    // save tracks to pool
+    // console.log('saving tracks to pool');
+    // await callApi({
+    //   method: 'POST',
+    //   path: `pool-tracks/by-pool/${poolId}`,
+    //   data: tracks,
+    // });
+    return tracks;
+  } else {
+    console.log('Could not retrieve tracks from spotify', errorMsg)
+    console.log('callSpotifyApi input', input)
+  }
+  // }
+  // const input = {
+  //   method: 'GET',
+  //   path: `pool-tracks/by-pool/${poolId}`,
+  //   token: currToken,
+  // }
+  // const { errorMsg, data } = await callApi(input);
+  // if (!errorMsg && data) {
+  //   return data;
+  // } else {
+  //   console.log('Could not retrieve tracks from db', errorMsg)
+  //   console.log('callApi input', input)A
+  // }
+}
+export const getRandomTrack = async (slot: FullSlot, callSpotifyApi: Function) => {
+  const { id: slotId, type, name, pool_id, pool_spotify_id } = slot;
+  let spotifyId = pool_spotify_id;
+  // TODO: figure out if this is timing I want for updating
+  // const poolNeedsUpdating = !pool_last_updated || new Date(pool_last_updated) < new Date(playlist.last_updated);
+  switch (type) {
+    case SLOT_TYPES_MAP_BY_NAME.track:
+      break;
+    case SLOT_TYPES_MAP_BY_NAME.album:
+      if (!pool_id || !pool_spotify_id) {
+        console.log('Expected pool_id & pool_spotify_id for album slot')
+        return;
+      }
+      // get album tracks
+      const albumTracks = await getAlbumTracks(pool_spotify_id, callSpotifyApi);
+      if (albumTracks) {
+        // pick a track
+        const track = pickRandomTrack(albumTracks);
+        if (track) {
+          // console.log('picking track', track.name, track.spotify_track_id);
+          spotifyId = track.spotify_track_id;
+        }
+      }
+      break;
+    case SLOT_TYPES_MAP_BY_NAME.artist:
+      if (!pool_id || !pool_spotify_id) {
+        console.log('Expected pool_id & pool_spotify_id for artist slot')
+        return;
+      }
+      // get artist albums
+      const { errorMsg, data } = await callSpotifyApi({
+        method: 'GET',
+        path: `artists/${pool_spotify_id}/albums`,
+      });
+      if (errorMsg) {
+        console.log('Error clearing playlist in Spotify', errorMsg);
+        return;
+      }
+      const { items } = data;
+      // get tracks from each album
+      const allTracks = (await Promise.all(items.map(async (album: any) => getAlbumTracks(album.id, callSpotifyApi)))).flat();
+      if (allTracks.length) {
+        // pick a track
+        const track = pickRandomTrack(allTracks);
+        if (track) {
+          // console.log('picking track', track.name, track.spotify_track_id);
+          spotifyId = track.spotify_track_id;
+        }
+      }
+      break;
+    default: console.log('Unexpected slot type', type);
+    // copilot just threw this in. Will check it later when I implement playlist support
+    // case SLOT_TYPES_MAP_BY_NAME.playlist:
+    //   // get playlist tracks
+    //   const { errorMsg: errorMsg2, data: data2 } = await callSpotifyApi({
+    //     method: 'GET',
+    //     path: `playlists/${pool_spotify_id}/tracks`,
+    //     token: currToken,
+    //   });
+    //   if (errorMsg2) {
+    //     console.log('Error clearing playlist in Spotify', errorMsg2);
+    //     return;
+    //   }
+    //   const { items: playlistTracks } = data2;
+    //   // save playlist tracks to pool
+    //   await callApi({
+    //     method: 'POST',
+    //     path: 'pool-tracks/',
+    //     data: playlistTracks.map(({ track }: any) => ({
+    //       pool_id,
+  }
+  if (!spotifyId) {
+    console.log('No spotifyId added for slot: ', slotId, ' name: ', name);
+  } else {
+    await callApi({
+      method: 'PUT',
+      path: `slots/${slotId}`,
+      data: {
+        current_track: spotifyId,
+        pool_spotify_id,
+      }
+    });
+    return `spotify:track:${spotifyId}`;
+  }
+}
+
+export const getDpPlaylist = async (playlistId: string) => {
+  return callApi({
+    method: 'GET',
+    path: `playlists/by-spotify-id/${playlistId}`,
+  })
+}
+
+export const getSpotifyPlaylist = async (playlistId: string, callSpotifyApi: Function) => {
+  return callSpotifyApi({
+    method: 'GET',
+    path: `playlists/${playlistId}`,
+  });
+}
+
+export const updateSlotWithNewTrack = async (slotId: string, trackId: string) => {
+  return callApi({
+    method: 'PUT',
+    path: `slots/${slotId}`,
+    data: {
+      current_track: trackId,
+    }
+  });
+}
+
+export const updateSpotifyPlaylistWithNewTrack = async (
+  playlistId: string,
+  position: number,
+  uri: string,
+  callSpotifyApi: Function
+) => {
+  console.log('adding track to spotify playlist', {
+    data: {
+      uris: [uri],
+      position,
+    },
+    method: "POST",
+    path: `playlists/${playlistId}/tracks`,
+  })
+  return callSpotifyApi({
+    data: {
+      uris: [uri],
+      position,
+    },
+    method: "POST",
+    path: `playlists/${playlistId}/tracks`,
+  });
+}
+
+export const deleteTrackFromSpotifyPlaylist = async (
+  playlistId: string,
+  snapshotId: string,
+  callSpotifyApi: Function,
+  uri?: string,
+) => {
+  if (!uri) {
+    throw new Error('missing uri');
+  }
+  return callSpotifyApi({
+    data: {
+      tracks: [{ uri }],
+      snapshotId,
+    },
+    method: "DELETE",
+    path: `playlists/${playlistId}/tracks`,
+  });
+}

--- a/client/src/utils/refreshToken.ts
+++ b/client/src/utils/refreshToken.ts
@@ -1,3 +1,4 @@
+import { setTokens } from ".";
 import authorizeSpotify from "./authorizeSpotify";
 import callApi from "./callApi";
 
@@ -5,6 +6,7 @@ const useRefreshToken = () => {
   const refreshToken = localStorage.getItem('refresh_token');
 
   const getNewToken = async (): Promise<string | null> => { 
+    console.log('refreshing token', refreshToken)
     const { errorMsg, data } = await callApi({
       method: 'POST',
       baseUrl: 'https://accounts.spotify.com/api/',
@@ -24,15 +26,18 @@ const useRefreshToken = () => {
       return null;
     }
     const { access_token, refresh_token } = data;
-    if (!access_token) {
-      throw new Error('Missing access token');
+    try {
+      const oldAccessToken = localStorage.getItem('access_token');
+      console.log('old / new refresh token', refreshToken, refresh_token);
+      console.log('old / new access token', oldAccessToken, access_token);
+      setTokens(access_token, refresh_token);
+      const newSavedAccessToken = localStorage.getItem('access_token');
+      const newSavedRefreshToken = localStorage.getItem('refresh_token');
+      console.log('new saved tokens. acccess / refresh', newSavedAccessToken, newSavedRefreshToken);
+    } catch (e) {
+      console.log('Error setting tokens: ', e);
     }
-    if (!refresh_token) {
-      throw new Error('Missing refresh token');
-    }
-      localStorage.setItem('refresh_token', refresh_token);
-      localStorage.setItem('access_token', access_token);
-      return access_token;
+    return access_token;
   };
   return { getNewToken };
 };

--- a/client/src/utils/useSpotifyApi.ts
+++ b/client/src/utils/useSpotifyApi.ts
@@ -44,7 +44,7 @@ const useSpotifyApi = () => {
       path = `${path}?${params.toString()}`;
     }
     let res;
-    if (!tokenExists(accessToken) && !tokenExists(refreshToken)) {
+    if (!options.skipToken && !tokenExists(accessToken) && !tokenExists(refreshToken)) {
       console.log('no access or refresh token, redirecting to login');
       redirect('/login');
     } else {
@@ -62,7 +62,6 @@ const useSpotifyApi = () => {
       }
       const accessTokenExpired = res.errorMsg && res.errorMsg.includes('expired');
       if (!accessToken || accessTokenExpired) {
-        console.log('Access token expired or missing. Attemping refresh.');
         const newAccessToken = await getNewToken();
         if (newAccessToken) {
           return callApi({

--- a/server/migrations/1695678532057_add-current-track-to-slot.sql
+++ b/server/migrations/1695678532057_add-current-track-to-slot.sql
@@ -1,0 +1,4 @@
+-- Up Migration
+ALTER TABLE slot ADD COLUMN current_track varchar(255);
+-- Down Migration
+ALTER TABLE slot DROP COLUMN current_track;

--- a/server/migrations/1696004922504_add-not-null-pool-spotify-id.sql
+++ b/server/migrations/1696004922504_add-not-null-pool-spotify-id.sql
@@ -1,0 +1,9 @@
+-- Up Migration: Pools now must have a spotify_id and if we delete a pool, we delete the slot related to it as well
+ALTER TABLE slot DROP CONSTRAINT slot_pool_id_fkey;
+ALTER TABLE slot ADD CONSTRAINT slot_pool_id_fkey FOREIGN KEY (pool_id) REFERENCES pool(id) ON DELETE CASCADE;
+DELETE FROM pool WHERE spotify_id IS NULL;
+ALTER TABLE pool ALTER COLUMN spotify_id SET NOT NULL;
+-- Down Migration
+ALTER TABLE pool ALTER COLUMN spotify_id DROP NOT NULL;
+ALTER TABLE slot DROP CONSTRAINT slot_pool_id_fkey;
+ALTER TABLE slot ADD CONSTRAINT slot_pool_id_fkey FOREIGN KEY (pool_id) REFERENCES pool(id);

--- a/server/routes/api/playlists/index.ts
+++ b/server/routes/api/playlists/index.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { getPlaylistById, getPlaylistsByUserId, createPlaylist, updatePlaylist, deletePlaylist } from '../../../services/playlist/index.js';
+import { getPlaylistById, getPlaylistsByUserId, createPlaylist, updatePlaylist, deletePlaylist, getPlaylistBySpotifyId } from '../../../services/playlist/index.js';
 import { Playlist } from '../../../types/index.js';
 
 const playlistsRouter = Router();
@@ -27,6 +27,17 @@ playlistsRouter.get('/by-user/:userId', async (req: Request, res: Response) => {
   try {
     const playlists = await getPlaylistsByUserId(userId);
     return res.status(200).send(playlists);
+  } catch (err: any) {
+    const errMsg = err?.message || err;
+    return res.status(500).json({ error: errMsg});
+  }
+});
+
+playlistsRouter.get('/by-spotify-id/:spotifyId', async (req: Request, res: Response) => {
+  const { spotifyId } = req.params;
+    try {
+    const playlist = await getPlaylistBySpotifyId(spotifyId);
+    return res.status(200).send(playlist);
   } catch (err: any) {
     const errMsg = err?.message || err;
     return res.status(500).json({ error: errMsg});

--- a/server/routes/api/pools/index.ts
+++ b/server/routes/api/pools/index.ts
@@ -1,5 +1,5 @@
 import { Router, Request, Response } from 'express';
-import { getPoolById, getPoolBySpotifyId, createPool, setPoolLastUpdated, deletePool } from '../../../services/pool/index.js';
+import { getPoolById, getPoolBySpotifyId, upsertPool, setPoolLastUpdated, deletePool } from '../../../services/pool/index.js';
 import { Pool } from '../../../types/index.js';
 
 const poolsRouter = Router();
@@ -39,7 +39,7 @@ poolsRouter.post('/', async (req: Request, res: Response) => {
   const pool: Omit<Pool, 'id' | 'last_updated'> = req.body;
 
   try {
-    const newPool = await createPool(pool);
+    const newPool = await upsertPool(pool);
     return res.status(201).send(newPool);
   } catch (err: any) {
     const errMsg = err?.message || err;

--- a/server/routes/api/slots/index.ts
+++ b/server/routes/api/slots/index.ts
@@ -30,8 +30,8 @@ slotsRouter.post('/', async (req, res) => {
 });
 
 slotsRouter.put('/:id', async (req, res) => {
-  const { spotify_id, ...slot } = req.body;
-  const newSlot = await updateSlot(req.params.id, slot, spotify_id);
+  const { pool_spotify_id, ...slot } = req.body;
+  const newSlot = await updateSlot(req.params.id, slot, pool_spotify_id);
   if (newSlot) {
     res.json(newSlot);
   } else {

--- a/server/services/playlist/index.ts
+++ b/server/services/playlist/index.ts
@@ -1,15 +1,14 @@
 import { pool } from '../../index.js';
-import { Playlist } from '../../types/index.js';
+import { Playlist, PlaylistWithSlots } from '../../types/index.js';
 
 const getPlaylistById = async (id: string): Promise<Playlist | null> => {
   const { rows } = await pool.query(
-    `SELECT playlist.*, slot.*
+    `SELECT *
      FROM playlist
-     JOIN slot ON playlist.id = slot.playlist_id
-     WHERE playlist.id = $1`,
+     WHERE id = $1`,
     [id]
   );
-  return rows.length > 0 ? rows[0] : null;
+  return rows[0];
 };
 
 const getPlaylistsByUserId = async (userId: string): Promise<Playlist[]> => {
@@ -20,6 +19,25 @@ const getPlaylistsByUserId = async (userId: string): Promise<Playlist[]> => {
     [userId]
   );
   return rows;
+};
+
+const getPlaylistBySpotifyId = async (spotifyId: string): Promise<PlaylistWithSlots> => {
+  const { rows } = await pool.query(
+    `SELECT playlist.*, json_agg(slot.*) AS slots
+    FROM playlist
+    LEFT JOIN slot ON playlist.id = slot.playlist_id
+    WHERE playlist.spotify_id = $1
+    GROUP BY playlist.id`,
+    [spotifyId]
+  );
+  // try {
+  //   rows[0].slots = JSON.parse(rows[0].slots);
+  // } catch (e) {
+  //   console.error('Error parsing slots: ', e);
+  //   console.log(rows);
+  // }
+  console.log(rows[0])
+  return rows[0];
 };
 
 const createPlaylist = async (playlist: Omit<Playlist, 'id' | 'created_at' | 'last_updated'>): Promise<Playlist> => {
@@ -73,6 +91,7 @@ const deletePlaylist = async (id: string): Promise<void> => {
 export {
   getPlaylistById,
   getPlaylistsByUserId,
+  getPlaylistBySpotifyId,
   createPlaylist,
   updatePlaylist,
   deletePlaylist,

--- a/server/services/pool/index.ts
+++ b/server/services/pool/index.ts
@@ -18,7 +18,7 @@ const getPoolBySpotifyId = async (spotifyId: string, market: string): Promise<Po
   return rows;
 };
 
-const createPool = async (pool: Omit<Pool, 'id' | 'last_updated'>): Promise<Pool> => {
+const upsertPool = async (pool: Omit<Pool, 'id' | 'last_updated'>): Promise<Pool> => {
   const { spotify_id } = pool;
   const { rows: poolRows } = await connectionPool.query(
     `SELECT *
@@ -58,7 +58,7 @@ const deletePool = async (id: string): Promise<void> => {
 export {
   getPoolById,
   getPoolBySpotifyId,
-  createPool,
+  upsertPool,
   setPoolLastUpdated,
   deletePool,
 };

--- a/server/types/index.ts
+++ b/server/types/index.ts
@@ -21,14 +21,15 @@ export type SlotType = typeof VALID_SLOT_TYPES[number];
 
 export interface Slot {
   id: UUID;
+  artist_name: string[];
   created_at: Date;
+  current_track?: string;
   last_updated: Date;
   name: string;
   playlist_id: UUID;
   pool_id?: UUID;
-  type: SlotType;
-  artist_name: string[];
   position: number;
+  type: SlotType;
 }
 
 export interface PoolTrack {
@@ -38,3 +39,6 @@ export interface PoolTrack {
   spotify_artist_ids?: Array<string>; // For future feature of banning artists
 }
 
+export interface PlaylistWithSlots extends Playlist {
+  slots: Array<Slot>;
+}


### PR DESCRIPTION
This PR:
- adds ability to dynamically update playlists while listening
  - sdk listener player state changes are rapid fire, so I set them to local state and handle the async functions in useEffect
- adds a play playlist button
- extracts a bunch of functions, most api calls in webplayback as well as `getRandomTrack` (Keeps files less cluttered and having a useful name like `getSpotifyPlaylist` is better than `callSpotifyApi` with a bunch of inputs imo)
- SLOT_TYPES ['track', 'playlist', album'] is now SLOT_TYPES_LIST and SLOT_TYPES is a map
   - SLOT_TYPES includes playlist, but confirmed this doesn't affect any of the other SLOT_TYPES_* values
- 2 migrations
  - add `slot.current_track: string` (spotify id) so we can easily find which slot the currently playing track belongs to
  - adds not null to `pool.spotify_id`
- adds `playlist/by-spotify-id/:id` route
  - returns playlist object with all related slots, including their related pools 
- creating a slot returns new pool info as well