### PR TITLE
filter appears on albums for artist slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   - finish error boundaries
   - Support drag n drop for slot positioning
   - separate playlist route so refresh doesn't take you away to home + back button to home
+    - also refresh selected playlist after publishing for the first time so it doesn't create multiple new playlists
   - Styling on mobile (icons taking up too much space)
   - <details>
       <summary>bugfix: auto update positions when deleting slots</summary>
@@ -34,12 +35,12 @@
         ```
     </details>
 - Smol
-  - delete playlist
   - tooltips for buttons
   - Scrolling for longer playlists + remove scroll for playlist items
   - Play a specific track in a playlist
   - header nav
   - delete account
+  - Are you sure? on delete list / slot
 
 Misc Todos:
 - Refactor pools

--- a/client/src/components/Playlist.tsx
+++ b/client/src/components/Playlist.tsx
@@ -139,11 +139,12 @@ function Playlist({
         setErrorSnackbar('Error creating new Spotify playlist.');
       }
     } else {
+      // clear existing playlist in spotify
+      await clearSpotifyPlaylist(callSpotifyApi, spotifyPlaylistId);
+    }
+    if (spotifyPlaylistId) {
       // TODO: Should probably create new playlist with same name & delete old one upon success?
       try {
-        // clear existing playlist in spotify
-        await clearSpotifyPlaylist(callSpotifyApi, spotifyPlaylistId);
-
         // update spotify playlist with current slots
         // convert each slot to a spotify uri of a track
         const uris = await Promise.all(slots.map(async (slot) => {
@@ -172,7 +173,7 @@ function Playlist({
         setErrorSnackbar('Error populating Spotify playlist.');
       }
     }
-  }  
+  }
 
   const selectSlotToEdit = (id: string) => {
     const slot = slots.find((slot) => slot.id === id);

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -46,6 +46,7 @@ export type SpotifyAlbumType = {
   id: string;
   name: string;
   artists: Array<SpotifyArtistType>;
+  album_group: string;
 }
 
 export type SpotifyPlaylistType = {

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -104,7 +104,11 @@ export const getRandomTrack = async (slot: FullSlot, callSpotifyApi: Function) =
       }
       const { items } = data;
       // get tracks from each album
-      const allTracks = (await Promise.all(items.map(async (album: any) => getAlbumTracks(album.id, callSpotifyApi)))).flat();
+      const allTracks = (await Promise.all(items.map(async (album: any) => {
+        if (album.album_group !== 'appears_on') {
+          return getAlbumTracks(album.id, callSpotifyApi)
+        }
+      }))).filter(item => !!item).flat();
       if (allTracks.length) {
         // pick a track
         const track = pickRandomTrack(allTracks);


### PR DESCRIPTION
This PR filters out compilation/appears on albums for artist slots
- Might add ability to add only the track(s) by the selected artist, but for now I'm going to just filter those albums out completely.
- Also fixes bug where it wasn't populating a newly created playlist