### PR TITLE
Playlist route

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@
 - Med
   - finish error boundaries
   - Support drag n drop for slot positioning
-  - separate playlist route so refresh doesn't take you away to home + back button to home
-    - also refresh selected playlist after publishing for the first time so it doesn't create multiple new playlists
   - Styling on mobile (icons taking up too much space)
   - <details>
       <summary>bugfix: auto update positions when deleting slots</summary>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import { AppBar, Typography, Toolbar } from '@mui/material';
 import RequestToken from './components/RequestToken';
 import Home from './components/Home';
 import ErrorBoundary from './components/ErrorBoundary';
+import Playlist from './components/Playlist';
 
 function App() {
 
@@ -32,6 +33,7 @@ function App() {
       <ErrorBoundary key='Webplayback'>
         <Routes>
           <Route path="/auth/callback" element={<RequestToken />} />
+          <Route path="/playlist/:playlistid" element={<Playlist />} />
           <Route path="/home/:userid" element={<Home />} />
           <Route path="/" element={<Landing />} />
         </Routes>

--- a/client/src/components/Home.tsx
+++ b/client/src/components/Home.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import ListItem from './presentational/ListItem';
 import WebPlayback from './WebPlayback';
-import { Typography, Container, Box, Paper, Button, DialogTitle, DialogContent } from '@mui/material';
+import { Typography, Box, Button, DialogTitle, DialogContent } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -9,20 +9,14 @@ import { useParams } from 'react-router-dom';
 import TextInput from './forms/inputs/TextInput';
 import { PlaylistType } from '../types/index.js';
 import Snackbar from './presentational/Snackbar';
-import Playlist from './Playlist';
 import BaseDialog from './forms/BaseDialog';
 import { useUserContext } from '../contexts/user';
-import { getErrorMessage } from '../utils';
 import { useSnackbarContext } from '../contexts/snackbar';
 import { createDpPlaylist, deleteDpPlaylist, getAllUserPlaylists } from '../utils/playlists/dp';
 import { getToken } from '../utils/tokens';
 import { ENVIRONMENTS } from '../constants';
 import ErrorBoundary from './ErrorBoundary';
-import { Delete } from '@mui/icons-material';
-
-const MainContainer = styled(Container)({
-  padding: '20px 0px 30px 0px'
-});
+import Page from './presentational/Page';
 
 const ListHeader = styled('div')({
   display: 'flex',
@@ -34,11 +28,6 @@ const YourLibraryTitle = styled(Typography)({
   fontWeight: 'bold',
   marginBottom: '15px',
   color: 'white',
-});
-
-const YourLibraryPaper = styled(Paper)({
-  padding: '20px',
-  background: 'transparent'
 });
 
 const WebPlaybackContainer = styled(Box)({
@@ -68,21 +57,9 @@ const StyledDialogContent = styled(DialogContent)({
 });
 
 const sortPlaylistsByLastUpdated = (playlists: PlaylistType[]) => {
-  // sort playlists by last updated, newest first. If no last updated, sort by created at
   return playlists.sort((a, b) => {
-    const aLastUpdated = new Date(a.last_updated);
-    const bLastUpdated = new Date(b.last_updated);
-    const aCreatedAt = new Date(a.created_at);
-    const bCreatedAt = new Date(b.created_at);
-    if (bLastUpdated === null && aLastUpdated === null) {
-      return bCreatedAt.getTime() - aCreatedAt.getTime();
-    } else if (bLastUpdated === null) {
-      return -1;
-    } else if (aLastUpdated === null) {
-      return 1;
-    } else if (bLastUpdated.getTime() === aLastUpdated.getTime()) {
-      return bCreatedAt.getTime() - aCreatedAt.getTime();
-    }
+    const aLastUpdated = new Date(a.last_updated || a.created_at);
+    const bLastUpdated = new Date(b.last_updated || b.created_at);
     return bLastUpdated.getTime() - aLastUpdated.getTime();
   });
 }
@@ -92,7 +69,6 @@ function Home() {
   const token = getToken();
   const [openCreatePlaylist, setOpenCreatePlaylist] = useState(false);
   const [newPlaylistTitle, setNewPlaylistTitle] = useState('');
-  const [selectedPlaylist, setSelectedPlaylist] = useState<PlaylistType>();
   const [playlists, setPlaylists] = useState<PlaylistType[]>([]);
   const { setUserIdContext } = useUserContext();
   const {
@@ -105,11 +81,12 @@ function Home() {
   const handleCreatePlaylist = async () => {
     if (userId) {
       try {
-        const newPlaylist = await createDpPlaylist(newPlaylistTitle, userId);
-        if (!newPlaylist) {
-          throw new Error('No data returned from create playlist request.');
+        const updatedPlaylists = await createDpPlaylist(newPlaylistTitle, userId);
+        if (!updatedPlaylists) {
+          setErrorSnackbar('Error getting updated playlists after deleting playlist.');
         } else {
-          setSelectedPlaylist(newPlaylist);
+          const sorted = sortPlaylistsByLastUpdated(updatedPlaylists);
+          setPlaylists(sorted);
         }
       } catch (e: any) {
         if (process.env.NODE_ENV === ENVIRONMENTS.development) {
@@ -125,19 +102,12 @@ function Home() {
 
   const handleDeletePlaylist = async (playlistId: string) => {
     try {
-      await deleteDpPlaylist(playlistId);
-      setSelectedPlaylist(undefined);
-      try {
-        const playlists = await getAllUserPlaylists(userId);
-        if (playlists && playlists.length) {
-          const sorted = sortPlaylistsByLastUpdated(playlists);
-          setPlaylists(sorted);
-        }
-      } catch (e) {
-        if (process.env.NODE_ENV === ENVIRONMENTS.development) {
-          console.log('error getting updated playlists after deleting playlist', e);
-        }
+      const updatedPlaylists = await deleteDpPlaylist(playlistId);
+      if (!updatedPlaylists) {
         setErrorSnackbar('Error getting updated playlists after deleting playlist.');
+      } else {
+        const sorted = sortPlaylistsByLastUpdated(updatedPlaylists);
+        setPlaylists(sorted);
       }
     } catch (e: any) {
       if (process.env.NODE_ENV === ENVIRONMENTS.development) {
@@ -156,11 +126,10 @@ function Home() {
   };
 
   const setSelectedPlaylistById = (id: string) => {
-    const selectedPlaylist = playlists.find(list => list.id === id)
-    if (!selectedPlaylist) {
-      setErrorSnackbar(`Selected playlist not found in playlists list.`);
+    if (!id) {
+      setErrorSnackbar(`Error selecting playlist.`);
     } else {
-      setSelectedPlaylist(selectedPlaylist);
+      window.location.href = `/playlist/${id}`;
     }
   }
 
@@ -178,7 +147,7 @@ function Home() {
   )
 
   useEffect(() => {
-    async function getPlaylists() {
+    const getPlaylists = async () => {
       try {
         const playlists = await getAllUserPlaylists(userId);
         if (playlists && playlists.length) {
@@ -197,54 +166,45 @@ function Home() {
       setUserIdContext(userId);
       getPlaylists();
     }
-  }, []);
+  }, [userId]);
 
 
   return (
     <main>
-      <MainContainer>
-        <YourLibraryPaper>
-          <div style={{ paddingBottom: '20%' }}>
-          {!selectedPlaylist ?
-              <ErrorBoundary key='All Playlists'>
-                <ListHeader>
-                  <YourLibraryTitle>Your Library</YourLibraryTitle>
-                  <CreatePlaylistButton variant="contained" onClick={openCreatePlaylistForm}>
-                    <AddIcon />
-                  </CreatePlaylistButton>
-                </ListHeader>
-                {playlists.map(playlist => {
-                  const innerContent =
-                    <ListItemInnerContent>
-                      <Typography variant="subtitle1" fontWeight="bold">{playlist.title}</Typography>
-                      <DeleteIcon onClick={() => handleDeletePlaylist(playlist.id)} />
-                    </ListItemInnerContent>
-                  return <ListItem
-                    key={playlist.id}
-                    id={playlist.id}
-                    innerContent={innerContent}
-                    onClick={setSelectedPlaylistById}
-                  />
-                })}
-              </ErrorBoundary>
-            :
-              <ErrorBoundary key='Selected Playlist'>
-                <Playlist
-                  playlist={selectedPlaylist}
-                />
-              </ErrorBoundary>
-          }
-          </div>
-          {token &&
-            <ErrorBoundary key='Webplayback'>
-              <WebPlaybackContainer>
-                <WebPlayback />
-              </WebPlaybackContainer>
-            </ErrorBoundary>
-          }
-        </YourLibraryPaper>
-
-      </MainContainer>
+      <Page>
+        <div style={{ paddingBottom: '20%' }}>
+          <ErrorBoundary key='All Playlists'>
+            <ListHeader>
+              <YourLibraryTitle>Your Library</YourLibraryTitle>
+              <CreatePlaylistButton variant="contained" onClick={openCreatePlaylistForm}>
+                <AddIcon />
+              </CreatePlaylistButton>
+            </ListHeader>
+            {playlists.map(playlist => {
+              const innerContent =
+                <ListItemInnerContent>
+                  <Typography variant="subtitle1" fontWeight="bold">{playlist.title}</Typography>
+                </ListItemInnerContent>
+              const deleteAction = <DeleteIcon onClick={() => handleDeletePlaylist(playlist.id)} />;
+              const actions = [deleteAction];
+              return <ListItem
+                key={playlist.id}
+                id={playlist.id}
+                innerContent={innerContent}
+                actions={actions}
+                onClick={setSelectedPlaylistById}
+              />
+            })}
+          </ErrorBoundary>
+        </div>
+        {token &&
+          <ErrorBoundary key='Webplayback'>
+            <WebPlaybackContainer>
+              <WebPlayback />
+            </WebPlaybackContainer>
+          </ErrorBoundary>
+        }
+      </Page>
       {
         openCreatePlaylist &&
         <ErrorBoundary key='Create Playlist Dialog'>

--- a/client/src/components/Login.tsx
+++ b/client/src/components/Login.tsx
@@ -1,54 +1,16 @@
-import useSpotifyApi from "../utils/useSpotifyApi";
 import { useUserContext } from "../contexts/user";
 import authorizeSpotify from "../utils/authorizeSpotify";
-import { tokenExists } from "../utils/tokens";
-import { getDpUser } from "../utils/users/dp";
-import { getSpotifyUser } from "../utils/users/spotify";
 import { ENVIRONMENTS } from "../constants";
 import { useSnackbarContext } from "../contexts/snackbar";
 
 function Login() {
-  const { callSpotifyApi } = useSpotifyApi();
-  const { setUserIdContext } = useUserContext();
+  const { userId } = useUserContext();
   const { setErrorSnackbar } = useSnackbarContext();
-  const accessToken = localStorage.getItem('access_token');
-  const previouslyAuthorized = tokenExists(accessToken);
 
   const startLogin = async () => {
     try {
-      if (previouslyAuthorized) {
-        if (process.env.NODE_ENV === ENVIRONMENTS.development) {
-          console.log('User previously authorized. Checking for user data.');
-        }
-        // get spotify user id
-        const spotifyUser = await getSpotifyUser(callSpotifyApi);
-        if (!spotifyUser) {
-          if (process.env.NODE_ENV === ENVIRONMENTS.development) {
-            console.log('No user data found. Attempting re-authorization.');
-          }
-          await authorizeSpotify();
-        } else {
-          const { id: spotifyUserId } = spotifyUser;
-          // double-check user exists in dp db as well
-          if (spotifyUserId) {
-            const dpUser = await getDpUser(spotifyUserId);
-            if (dpUser) {
-              setUserIdContext(dpUser.id);
-              // @ts-expect-error
-              window.location = '/home/' + dpUser.id;
-            } else {
-              if (process.env.NODE_ENV === ENVIRONMENTS.development) {
-                console.log('User not found in db. Attempting re-authorization.')
-              }
-              await authorizeSpotify();
-            }
-          } else {
-            if (process.env.NODE_ENV === ENVIRONMENTS.development) {
-              console.log('Spotify user id not found. Attempting re-authorization.')
-            }
-            await authorizeSpotify();
-          }
-        }
+      if (userId) {
+        window.location.href = '/home/' + userId;
       } else {
         await authorizeSpotify();
       }

--- a/client/src/components/Playlist.tsx
+++ b/client/src/components/Playlist.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Typography, Button } from '@mui/material';
+import { Typography, Button, Backdrop, CircularProgress } from '@mui/material';
 import { styled } from '@mui/material/styles';
 import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
@@ -20,7 +20,7 @@ import { getRandomTrack, requiresArtist } from '../utils';
 import useSpotifyApi from '../utils/useSpotifyApi';
 import { useUserContext } from '../contexts/user';
 import { useSnackbarContext } from '../contexts/snackbar';
-import { linkSpotifyPlaylistToDpPlaylist } from '../utils/playlists/dp';
+import { getPlaylistWithSlots, linkSpotifyPlaylistToDpPlaylist } from '../utils/playlists/dp';
 import {
   publishSpotifyPlaylist,
   playPlaylistInSpotify,
@@ -28,6 +28,8 @@ import {
   populateSpotifyPlaylist
 } from '../utils/playlists/spotify';
 import { editOrCreateSlot, deleteSlot, getSlotsByPlaylistId } from '../utils/slots';
+import { useParams } from 'react-router-dom';
+import Page from './presentational/Page';
 
 const iconTypeMapping = {
   [SLOT_TYPES_MAP_BY_NAME.track]: <AudiotrackIcon />,
@@ -66,13 +68,9 @@ const SlotInnerContent = styled('div')({
   },
 });
 
-type Props = {
-  playlist: PlaylistType;
-}
-
-function Playlist({
-  playlist,
-}: Props) {
+function Playlist() {
+  const { playlistid: playlistId } = useParams();
+  const [playlist, setPlaylist] = useState<PlaylistType | null>(null);
   const [slots, setSlots] = useState<FullSlot[]>([]);
   const [selectedEntry, setSelectedEntry] = useState<SpotifyEntry | null>(null);
   const [openEditSlotDialog, setOpenEditSlotDialog] = useState(false);
@@ -111,6 +109,10 @@ function Playlist({
   }
 
   const publishPlaylist = async () => {
+    if (!playlist) {
+      setErrorSnackbar('No selectedPlaylist to publish.');
+      return;
+    }
     let spotifyPlaylistId = playlist.spotify_id;
     // if playlist has never been published before, create new playlist in spotify
     // TODO: support descriptions
@@ -125,18 +127,19 @@ function Playlist({
         }
         try {
         // save spotify playlist id to playlist in dp db
-          await linkSpotifyPlaylistToDpPlaylist(playlist.id, spotifyPlaylistId, userId);
+          const updatedPlaylist = await linkSpotifyPlaylistToDpPlaylist(playlist.id, spotifyPlaylistId, userId);
+          setPlaylist(updatedPlaylist);
         } catch (e) {
           if (process.env.NODE_ENV === ENVIRONMENTS.development) {
             console.log(e);
           }
-          setErrorSnackbar('Spotify playlist created, but error linking to DP playlist.');
+          setErrorSnackbar('Spotify playlist created, but error linking to DP selectedPlaylist.');
         }
       } catch (e) {
         if (process.env.NODE_ENV === ENVIRONMENTS.development) {
           console.log(e);
         }
-        setErrorSnackbar('Error creating new Spotify playlist.');
+        setErrorSnackbar('Error creating new Spotify selectedPlaylist.');
       }
     } else {
       // clear existing playlist in spotify
@@ -170,7 +173,7 @@ function Playlist({
         if (process.env.NODE_ENV === ENVIRONMENTS.development) {
           console.log(e);
         }
-        setErrorSnackbar('Error populating Spotify playlist.');
+        setErrorSnackbar('Error populating Spotify selectedPlaylist.');
       }
     }
   }
@@ -190,6 +193,10 @@ function Playlist({
   }
 
   const handleEditSlotSubmit = async () => {
+    if (!playlist) {
+      setErrorSnackbar('No selected playlist to edit.');
+      return;
+    }
     if (selectedEntry && selectedOption?.value) {
       try {
         const newSlot: BaseSlot = {
@@ -244,75 +251,98 @@ function Playlist({
   }
 
   const playPlaylist = async () => {
+    if (!playlist) {
+      setErrorSnackbar('No selected playlist to play.');
+      return;
+    }
     try {
       await playPlaylistInSpotify(callSpotifyApi, playlist.spotify_id);
     } catch (e) {
       if (process.env.NODE_ENV === ENVIRONMENTS.development) {
         console.log(e);
       }
-      setErrorSnackbar('Error playing playlist.');
+      setErrorSnackbar('Error playing selectedPlaylist.');
     }
   }
 
   useEffect(() => {
 
     async function getPlaylist() {
+      if (!playlistId) {
+        return;
+      }
       try {
-        const slots = await getSlotsByPlaylistId(playlist.id);
-        setSlots(slots);
+        const playlist = await getPlaylistWithSlots(playlistId);
+        if (!playlist) {
+          window.location.href = '/';
+        }
+        setPlaylist(playlist);
+        setSlots(playlist.slots || []);
       } catch (e) {
         if (process.env.NODE_ENV === ENVIRONMENTS.development) {
           console.log(e);
         }
-        setErrorSnackbar('Error getting playlist.');
+        setErrorSnackbar('Error getting selectedPlaylist.');
       }
     }
+    if (playlistId) {
+      getPlaylist();
+    }
+  }, [playlistId]);
 
-    getPlaylist();
-
-  }, [playlist.id]);
+  if (!playlist) {
+    return (
+      <Backdrop
+        open={true}
+      >
+        <CircularProgress color="inherit" />
+      </Backdrop>
+    )
+  }
 
   return (
-    <>
-      <ListHeader>
-        <ListTitle>{playlist.title}</ListTitle>
-        <PlaylistActionsContainer>
-          <PlaylistActionButton variant="contained" onClick={playPlaylist}>
-            <PlayCircleIcon />
-          </PlaylistActionButton>
-          <PlaylistActionButton variant="contained" onClick={openCreateSlotForm}>
-            <AddIcon />
-          </PlaylistActionButton>
-          <PlaylistActionButton variant="contained" onClick={publishPlaylist}>
-            <PublishIcon />
-          </PlaylistActionButton>
-        </PlaylistActionsContainer>
-      </ListHeader>
-      {slots.map(slot => {
-        const label = slot.name + (requiresArtist(slot.type) && slot.artist_name?.length ? ' - ' + slot.artist_name.join(', ') : '')
-        const innerContent = (
-          <SlotInnerContent>
-            <div className="scroll-container" style={{ marginLeft: '10px', display: 'flex', alignItems: 'center', width: '80%', flexGrow: '1' }}>
-              <div className={label.length > 24 ? "scroll-content" : ""} style={{ fontSize: '1rem' }}>
-                {label}
+    <main>
+      <Page>
+        <ListHeader>
+          <ListTitle>{playlist.title}</ListTitle>
+          <PlaylistActionsContainer>
+            <PlaylistActionButton variant="contained" onClick={playPlaylist}>
+              <PlayCircleIcon />
+            </PlaylistActionButton>
+            <PlaylistActionButton variant="contained" onClick={openCreateSlotForm}>
+              <AddIcon />
+            </PlaylistActionButton>
+            <PlaylistActionButton variant="contained" onClick={publishPlaylist}>
+              <PublishIcon />
+            </PlaylistActionButton>
+          </PlaylistActionsContainer>
+        </ListHeader>
+        {slots.map(slot => {
+          const label = slot.name + (requiresArtist(slot.type) && slot.artist_name?.length ? ' - ' + slot.artist_name.join(', ') : '')
+          const innerContent = (
+            <SlotInnerContent>
+              <div className="scroll-container" style={{ marginLeft: '10px', display: 'flex', alignItems: 'center', width: '80%', flexGrow: '1' }}>
+                <div className={label.length > 24 ? "scroll-content" : ""} style={{ fontSize: '1rem' }}>
+                  {label}
+                </div>
               </div>
-            </div>
-            <div>
-              <DeleteIcon onClick={() => handleDeleteSlot(slot.id)} />
-              <EditIcon style={{ marginRight: '5px' }} onClick={() => selectSlotToEdit(slot.id)} />
-            </div>
-          </SlotInnerContent>
-        );
-        return (
-          <ListItem
-            key={slot.id}
-            id={slot.id}
-            icon={iconTypeMapping[slot.type]}
-            innerContent={innerContent}
-          />
-        )
-      })
-      }
+              <div>
+                <DeleteIcon onClick={() => handleDeleteSlot(slot.id)} />
+                <EditIcon style={{ marginRight: '5px' }} onClick={() => selectSlotToEdit(slot.id)} />
+              </div>
+            </SlotInnerContent>
+          );
+          return (
+            <ListItem
+              key={slot.id}
+              id={slot.id}
+              icon={iconTypeMapping[slot.type]}
+              innerContent={innerContent}
+            />
+          )
+        })
+        }
+      </Page>
       {
         openEditSlotDialog &&
         <BaseDialog
@@ -325,7 +355,7 @@ function Playlist({
           submitText={selectedSlot ? 'Edit' : 'Create'}
         />
       }
-    </>
+    </main>
   );
 }
 

--- a/client/src/components/Playlist.tsx
+++ b/client/src/components/Playlist.tsx
@@ -133,13 +133,13 @@ function Playlist() {
           if (process.env.NODE_ENV === ENVIRONMENTS.development) {
             console.log(e);
           }
-          setErrorSnackbar('Spotify playlist created, but error linking to DP selectedPlaylist.');
+          setErrorSnackbar('Spotify playlist created, but error linking to DP playlist.');
         }
       } catch (e) {
         if (process.env.NODE_ENV === ENVIRONMENTS.development) {
           console.log(e);
         }
-        setErrorSnackbar('Error creating new Spotify selectedPlaylist.');
+        setErrorSnackbar('Error creating new Spotify playlist.');
       }
     } else {
       // clear existing playlist in spotify
@@ -173,7 +173,7 @@ function Playlist() {
         if (process.env.NODE_ENV === ENVIRONMENTS.development) {
           console.log(e);
         }
-        setErrorSnackbar('Error populating Spotify selectedPlaylist.');
+        setErrorSnackbar('Error populating Spotify playlist.');
       }
     }
   }
@@ -261,7 +261,7 @@ function Playlist() {
       if (process.env.NODE_ENV === ENVIRONMENTS.development) {
         console.log(e);
       }
-      setErrorSnackbar('Error playing selectedPlaylist.');
+      setErrorSnackbar('Error playing selected playlist.');
     }
   }
 
@@ -282,7 +282,7 @@ function Playlist() {
         if (process.env.NODE_ENV === ENVIRONMENTS.development) {
           console.log(e);
         }
-        setErrorSnackbar('Error getting selectedPlaylist.');
+        setErrorSnackbar('Error getting selected playlist.');
       }
     }
     if (playlistId) {

--- a/client/src/components/Presentational/ListItem.tsx
+++ b/client/src/components/Presentational/ListItem.tsx
@@ -1,4 +1,4 @@
-import { Box, Card } from '@mui/material';
+import { Box, Card, CardActions } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
 const ListItemCard = styled(Card)({
@@ -22,6 +22,7 @@ const StyledIconBox = styled(Box)({
 });
 
 type Props = {
+  actions?: Array<JSX.Element>;
   id: string;
   icon?: JSX.Element;
   innerContent: JSX.Element;
@@ -29,14 +30,15 @@ type Props = {
 }
 
 function ListItem({
+  actions,
   id,
   icon,
   innerContent,
   onClick
 }: Props) {
   return (
-    <ListItemCard onClick={() => onClick && onClick(id)}>
-      <StyledCardContent style={{ flexGrow: '1' }}>
+    <ListItemCard>
+      <StyledCardContent style={{ flexGrow: '1' }} onClick={() => onClick && onClick(id)}>
         {icon &&
           <StyledIconBox>
             {icon}
@@ -44,7 +46,10 @@ function ListItem({
         }
         {innerContent}
       </StyledCardContent>
-    </ListItemCard>
+      <CardActions>
+        {actions}
+      </CardActions>
+    </ListItemCard >
   );
 }
 

--- a/client/src/components/Presentational/Page.tsx
+++ b/client/src/components/Presentational/Page.tsx
@@ -1,0 +1,26 @@
+import styled from "@emotion/styled";
+import { Container, Paper } from "@mui/material";
+
+const MainContainer = styled(Container)({
+  padding: '20px 0px 30px 0px'
+});
+
+const StyledPaper = styled(Paper)({
+  padding: '20px',
+  background: 'transparent'
+});
+
+
+type PageProps = {
+  children: React.ReactNode;
+};
+
+const Page = ({ children }: PageProps) => (
+  <MainContainer>
+    <StyledPaper>
+      {children}
+    </StyledPaper>
+  </MainContainer>
+);
+
+export default Page;

--- a/client/src/contexts/user.tsx
+++ b/client/src/contexts/user.tsx
@@ -1,6 +1,11 @@
 import {
-  ReactNode, createContext, useContext, useState
+  ReactNode, createContext, useContext, useEffect, useState
 } from 'react';
+import { getSpotifyUser } from '../utils/users/spotify';
+import useSpotifyApi from '../utils/useSpotifyApi';
+import { tokenExists } from '../utils/tokens';
+import authorizeSpotify from '../utils/authorizeSpotify';
+import { getDpUser } from '../utils/users/dp';
 
 interface Props {
   children: ReactNode
@@ -14,7 +19,11 @@ interface UserContextInterface {
 export const UserContext = createContext({});
 
 export const UserContextProvider = ({ children }: Props) => {
+  const { callSpotifyApi } = useSpotifyApi();
   const [userId, setUserId] = useState<string>('');
+  const accessToken = localStorage.getItem('access_token');
+  const previouslyAuthorized = tokenExists(accessToken);
+
   const setUserIdContext = (newUserId: string) => {
     setUserId(newUserId);
   };
@@ -22,6 +31,32 @@ export const UserContextProvider = ({ children }: Props) => {
     userId,
     setUserIdContext,
   };
+
+  useEffect(() => {
+    const getUser = async () => {
+      try {
+        const spotifyUser = await getSpotifyUser(callSpotifyApi);
+        if (spotifyUser) {
+          const { id: spotifyUserId } = spotifyUser;
+          // double-check dp user exists too
+          const dpUser = await getDpUser(spotifyUserId);
+          if (dpUser) {
+            setUserId(spotifyUserId);
+          } else {
+            throw new Error(`Matching Dp user does not exist for Spotify user ${spotifyUserId}`);
+          }
+        }
+      } catch (e: any) {
+        if (process.env.NODE_ENV === 'development') {
+          console.log('error getting spotify user', e);
+        }
+        await authorizeSpotify();
+      }
+    }
+    if (!userId && previouslyAuthorized) {
+      getUser();
+    }
+  }, [userId]);
 
   return (
     <UserContext.Provider value={userContext}>

--- a/client/src/utils/playlists/dp.ts
+++ b/client/src/utils/playlists/dp.ts
@@ -1,24 +1,33 @@
 import { PlaylistType, PlaylistWithSlots } from "../../types";
 import callApi from "../callApi";
 
-export const createDpPlaylist = async (title: string, userId: string):Promise<PlaylistType> => {
-  const { data } = await callApi({
+export const createDpPlaylist = async (title: string, userId: string):Promise<Array<PlaylistType>> => {
+  const { data: updatedUserPlaylists } = await callApi({
     method: 'POST',
-    path: 'playlists',
+    path: 'playlists?return_all=true',
     data: {
       created_by: userId,
       last_updated_by: userId,
       title
     }
   });
-  return data;
+  return updatedUserPlaylists;
 }
 
-export const deleteDpPlaylist = async (playlistId: string):Promise<void> => {
-  await callApi({
+export const deleteDpPlaylist = async (playlistId: string):Promise<Array<PlaylistType>> => {
+  const { data: updatedUserPlaylists } = await callApi({
     method: 'DELETE',
-    path: `playlists/${playlistId}`,
+    path: `playlists/${playlistId}?return_all=true`,
   });
+  return updatedUserPlaylists;
+}
+
+export const getPlaylistWithSlots = async (playlistId: string):Promise<PlaylistWithSlots> => {
+  const { data } = await callApi({
+    method: 'GET',
+    path: `playlists/${playlistId}?include=slots`,
+  });
+  return data;
 }
 
 export const getDpPlaylistBySpotifyId = async (playlistId: string):Promise<PlaylistWithSlots> => {

--- a/server/services/playlist/index.ts
+++ b/server/services/playlist/index.ts
@@ -80,8 +80,9 @@ const updatePlaylist = async (id: string, playlist: Partial<Omit<Playlist, 'id' 
   return playlistRow;
 };
 
-const deletePlaylist = async (id: string): Promise<void> => {
-  await pool.query('DELETE FROM playlist WHERE id = $1', [id]);
+const deletePlaylist = async (id: string): Promise<Playlist> => {
+  const { rows } = await pool.query('DELETE FROM playlist WHERE id = $1 RETURNING *', [id]);
+  return rows[0];
 };
 
 export {

--- a/server/types/index.ts
+++ b/server/types/index.ts
@@ -40,5 +40,5 @@ export interface PoolTrack {
 }
 
 export interface PlaylistWithSlots extends Playlist {
-  slots: Array<Slot>;
+  slots?: Array<Slot>;
 }


### PR DESCRIPTION
This PR moves the Playlist component out of Home to its own route. This allows users to remain on the playlist when refreshing the page.
- Bugfix: cleaned up sorting logic so it goes by `last_updated` || `created_at`. Previously was preferring `last_updated` existing over any value for `created_at`
- added `return_all` options for create and delete playlists to return the updated list of user's playlists
  - delete playlist returns deleted playlist
- new <Page> component so page styling remains the same between Home and Playlists
- Moved delete button to separate ItemActions section to avoid hitting selectPlaylist function while deleting
  - Note: I might change how this works later depending on what I do with how slots work. I want to make it similar to Spotify, so might have clicking on the slot play, clicking on playlist goes to the list, deleting & other actions go in a hamburger menu on right.
- moves getting user id logic into `userContext`